### PR TITLE
Fix missing channel after Connect

### DIFF
--- a/broker/mockbroker.go
+++ b/broker/mockbroker.go
@@ -17,8 +17,8 @@ type MockBroker struct {
 }
 
 // NewMockBroker creates a Mock Broker instance ready for testing.
-func NewMockBroker() MockBroker {
-	return MockBroker{
+func NewMockBroker() *MockBroker {
+	return &MockBroker{
 		inc: make(chan amqp.Delivery, 10),
 		out: make(chan amqp.Delivery, 10),
 	}
@@ -26,28 +26,28 @@ func NewMockBroker() MockBroker {
 
 // Connect only serves to complete the Broker interface. It returns the mock
 // message channel
-func (m MockBroker) Connect() (<-chan amqp.Delivery, error) {
+func (m *MockBroker) Connect() (<-chan amqp.Delivery, error) {
 	return m.inc, nil
 }
 
 // Close closes the test queue.
-func (m MockBroker) Close() {
+func (m *MockBroker) Close() {
 	close(m.inc)
 	close(m.out)
 }
 
 // SendMessage sends a message onto the outgoing queue
-func (m MockBroker) SendMessage(msg payload.Message) error {
+func (m *MockBroker) SendMessage(msg payload.Message) error {
 	m.addMessageToQueue(m.out, msg)
 	return nil
 }
 
 // DeliverMessage puts a message onto the incoming queue
-func (m MockBroker) DeliverMessage(msg payload.Message) {
+func (m *MockBroker) DeliverMessage(msg payload.Message) {
 	m.addMessageToQueue(m.inc, msg)
 }
 
-func (m MockBroker) addMessageToQueue(q chan amqp.Delivery, msg payload.Message) error {
+func (m *MockBroker) addMessageToQueue(q chan amqp.Delivery, msg payload.Message) error {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (m MockBroker) addMessageToQueue(q chan amqp.Delivery, msg payload.Message)
 
 // TakeMessage pops a message from the outgoing queue, of one is available. Does
 // not block.
-func (m MockBroker) TakeMessage(d time.Duration) (*payload.Message, error) {
+func (m *MockBroker) TakeMessage(d time.Duration) (*payload.Message, error) {
 	select {
 	case d := <-m.out:
 		return payload.MessageFromByteSlice(d.Body)

--- a/broker/rabbitmq.go
+++ b/broker/rabbitmq.go
@@ -26,8 +26,8 @@ type RabbitMQ struct {
 }
 
 // NewRabbitMQ creates a RabbitMQ instance ready to connect.
-func NewRabbitMQ(URI, qname string) RabbitMQ {
-	return RabbitMQ{
+func NewRabbitMQ(URI, qname string) *RabbitMQ {
+	return &RabbitMQ{
 		URI:   URI,
 		qname: qname,
 	}
@@ -35,7 +35,7 @@ func NewRabbitMQ(URI, qname string) RabbitMQ {
 
 // Connect opens up a RabbitMQ connection and returns a channel through which
 // Messages are delivered.
-func (r RabbitMQ) Connect() (<-chan amqp.Delivery, error) {
+func (r *RabbitMQ) Connect() (<-chan amqp.Delivery, error) {
 	var err error
 	r.conn, err = amqp.Dial(r.URI)
 	if err != nil {
@@ -90,7 +90,7 @@ func (r RabbitMQ) Connect() (<-chan amqp.Delivery, error) {
 // Close terminates the RabbitMQ channel and connection. Should be used when
 // running a Producer, after Connect is called. Automatically called after
 // Shutdown for a running Consumer.
-func (r RabbitMQ) Close() {
+func (r *RabbitMQ) Close() {
 	if r.ch != nil {
 		r.ch.Close()
 		r.ch = nil
@@ -102,7 +102,7 @@ func (r RabbitMQ) Close() {
 }
 
 // SendMessage sends a message onto the message's current Slip queue
-func (r RabbitMQ) SendMessage(msg payload.Message) error {
+func (r *RabbitMQ) SendMessage(msg payload.Message) error {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return err

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -46,7 +46,7 @@ func TestConsumer(t *testing.T) {
 	}
 
 	c := ge.NewConsumer("mock://", "test", 1, operator)
-	m := c.Broker.(broker.MockBroker)
+	m := c.Broker.(*broker.MockBroker)
 
 	if err := c.Run(); err != nil {
 		t.Errorf("Unexpected error: %+v", err)
@@ -110,7 +110,7 @@ func TestConsumerPing(t *testing.T) {
 	}
 
 	c := ge.NewConsumer("mock://", "test", 1, operator)
-	m := c.Broker.(broker.MockBroker)
+	m := c.Broker.(*broker.MockBroker)
 
 	if err := c.Run(); err != nil {
 		t.Errorf("Unexpected error: %+v", err)
@@ -184,7 +184,7 @@ func TestConsumerFailure(t *testing.T) {
 	}
 
 	c := ge.NewConsumer("mock://", "test", 1, operator)
-	m := c.Broker.(broker.MockBroker)
+	m := c.Broker.(*broker.MockBroker)
 
 	if err := c.Run(); err != nil {
 		t.Errorf("Unexpected error: %+v", err)

--- a/producer_test.go
+++ b/producer_test.go
@@ -23,7 +23,7 @@ func TestNewProducerConnectCloseWithError(t *testing.T) {
 
 func TestProducer(t *testing.T) {
 	p := ge.NewProducer("mock://", "test")
-	m := p.Broker.(broker.MockBroker)
+	m := p.Broker.(*broker.MockBroker)
 
 	if _, err := p.Connect(); err != nil {
 		t.Errorf("Unexpected error: %+v", err)


### PR DESCRIPTION
RabbitMQ Broker `Connect()` takes pointer argument, otherwise the channel is missing once connected.